### PR TITLE
conform ns form to spec

### DIFF
--- a/src/net/cgrand/xml.clj
+++ b/src/net/cgrand/xml.clj
@@ -3,7 +3,7 @@
 
   Most actual functionality has been moved into the
   net.cgrand.parser NS."
-  (require [net.cgrand.parser :as p]
+  (:require [net.cgrand.parser :as p]
            [net.cgrand.parser.sax :as sax]))
 
 (def tag p/tag)


### PR DESCRIPTION
`(require` within an ns form is no longer allowed in clojure-1.9 and causes spec failures.